### PR TITLE
#71/links to comment

### DIFF
--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -1143,11 +1143,13 @@ object {
 .widget_recent_comments .comment .time {
     float: left;
     max-width: 100%;
+    color: #1e4a66;
 }
 
 .widget_recent_comments .comment {
     display: block;
-    margin-bottom: 1.5em;
+    padding: 0 25px;
+    margin: 0 -25px 1.5em -25px;
 }
 
 #discussion .name {
@@ -1222,8 +1224,15 @@ object {
     padding-left: 25px;
 }
 
+/*.widget_recent_comments .comment:hover,*/
 #discussion .singleComment:hover {
     background-color: #f8f8f8;
+}
+.widget_recent_comments .comment a {
+    color: inherit;
+}
+.widget_recent_comments .comment a:hover {
+    color: #ea5449;
 }
 
 #discussion ol {

--- a/src/main/resources/assets/css/style.css
+++ b/src/main/resources/assets/css/style.css
@@ -1127,6 +1127,12 @@ object {
     margin-right: .5em;
 }
 
+#discussion .comment-anchor::before {
+    content: "";
+    display: block;
+    height: 120px;
+    margin-top: -120px;
+}
 
 #discussion .time::after,
 .widget_recent_comments .comment .time::after {
@@ -1182,6 +1188,7 @@ object {
 
 #discussion .text {
     margin-bottom: .25em;
+    padding-right: 25px;
 }
 
 #discussion .top {

--- a/src/main/resources/site/parts/comment-field/comment-single.html
+++ b/src/main/resources/site/parts/comment-field/comment-single.html
@@ -1,6 +1,6 @@
 <div>
     <div data-th-fragment="single (comment, last)" data-th-remove="tag">
-        <li data-th-id="|comment-${ comment._id }|">
+        <li class="comment-anchor" data-th-id="|comment-${ comment._id }|">
             <div class="singleComment">
                 <div class="top">
                     <span class="name" data-th-text="${ comment.userName }"></span>

--- a/src/main/resources/site/parts/latest-comments/latest-comments.html
+++ b/src/main/resources/site/parts/latest-comments/latest-comments.html
@@ -4,7 +4,7 @@
         <div data-th-if="${comment}" data-th-remove="tag">
             <b class="comment-item name" data-th-text="${ comment.userName }"></b>
             <time class="comment-item time" data-th-text="${ comment.time }"></time>
-            <q class="comment-item text">[[${ comment.text }]]</q>
+            <a data-th-href="|${ comment.contentUrl }#comment-${ comment._id }|" class="comment-item text">[[${ comment.text }]]</a>
         </div>
         <span class="comment-item post">[[${ local.on }]] <a data-th-href="${ comment.contentUrl }" data-th-text="${ comment.contentName }"></a></span>
     </div>

--- a/src/main/resources/site/parts/latest-comments/latest-comments.html
+++ b/src/main/resources/site/parts/latest-comments/latest-comments.html
@@ -1,11 +1,11 @@
 <aside id="latestDiscussion" class="widget widget_recent_comments">
     <h3 class="widget-title" data-th-if="${ headline }" data-th-text="${ headline }"></h3>
     <div class="comment" data-th-each="comment : ${ comments }">
-        <div data-th-if="${comment}" data-th-remove="tag">
+        <a data-th-href="|${ comment.contentUrl }#comment-${ comment._id }|" data-th-if="${comment}">
             <b class="comment-item name" data-th-text="${ comment.userName }"></b>
             <time class="comment-item time" data-th-text="${ comment.time }"></time>
-            <a data-th-href="|${ comment.contentUrl }#comment-${ comment._id }|" class="comment-item text">[[${ comment.text }]]</a>
-        </div>
+            <q class="comment-item text">[[${ comment.text }]]</q>
+        </a>
         <span class="comment-item post">[[${ local.on }]] <a data-th-href="${ comment.contentUrl }" data-th-text="${ comment.contentName }"></a></span>
     </div>
 </aside>

--- a/src/main/resources/site/parts/latest-comments/latest-comments.xml
+++ b/src/main/resources/site/parts/latest-comments/latest-comments.xml
@@ -7,8 +7,9 @@
             <items>
                 <input type="TextLine" name="headline">
                     <label>Title</label>
-                    <default></default>
+                    <default>Latest comments</default>
                     <help-text>The headline text displayed on this part</help-text>
+                    <occurrences minimum="1" maximum="1"></occurrences>
                 </input>
                 <input type="Long" name="size">
                     <label>How many comments to show?</label>
@@ -17,6 +18,7 @@
                         <min>1</min>
                         <max>20</max>
                     </config>
+                    <occurrences minimum="1" maximum="1"></occurrences>
                 </input>
             </items>
         </field-set>


### PR DESCRIPTION
Also restyled the recent-comments part for link target clarity... 

Un-hovered:
![image](https://user-images.githubusercontent.com/5279775/101921504-61330480-3bcd-11eb-9223-22c5770a4784.png)

Hovering over the Testing testing comment (both comment and user/time hovering will look like this):
![image](https://user-images.githubusercontent.com/5279775/101921700-94759380-3bcd-11eb-9893-103824460e2a.png)

