### PR TITLE
fix: featured part not reloaded by Content Studio when added or changed #164

### DIFF
--- a/src/main/resources/cms/parts/featured/featured.js
+++ b/src/main/resources/cms/parts/featured/featured.js
@@ -96,6 +96,11 @@ exports.get = function handleGet(req) {
     }
 
     return {
-        body: thymeleaf.render(view, model)
+        body: thymeleaf.render(view, model),
+        pageContributions: req.mode === 'edit' ? {
+            bodyEnd: [
+                `<script>jQuery(function($){ $('.flexslider').flexslider({slideshow: true, prevText: '', nextText: ''}); });</script>`
+            ]
+        } : undefined
     };
 }


### PR DESCRIPTION
## Changes

- Returned a `bodyEnd` page contribution from `featured.js` in edit mode so Content Studio sets `X-Has-Contributions` and reloads the iframe when the part is added or its descriptor changes.
- Re-initialized flexslider inside the contribution so parts inserted after `$(document).ready` rebind the slider behavior.

Closes #164

<sub>*Drafted with AI assistance*</sub>
