### PR TITLE
Migrate to XP 8 lib-project API

### DIFF
--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -11,9 +11,7 @@ const projectData = {
     displayName: 'Superhero Blog',
     description: 'Sample blog site on Enonic XP',
     language: 'en',
-    readAccess: {
-        public: true
-    }
+    publicRead: true
 }
 
 


### PR DESCRIPTION
## Summary

Flip the `projectData` literal in `src/main/resources/main.js` from the XP 7 nested `readAccess: { public: true }` shape to the flat `publicRead: true` required by `/lib/xp/project` on XP 8.

The platform PR enonic/xp#12043 removed the nested shape with no backward-compat shim, so the old form fails at runtime on XP 8 master.

Sole call site in this app is the startup hook (`projectLib.create(projectData)`); no `modifyReadAccess`, no `projectLib.modify`, and no other `readAccess` references in the source tree.

See the [lib-project upgrade-notes section](https://github.com/enonic/doc-code/blob/master/docs/upgrade.adoc#lib-project) in `doc-code` for the full XP 7 → XP 8 mapping.

## Test plan

- [x] `./gradlew build` — green
- [ ] CI run on this branch — green
- [ ] On XP 8 master, app starts and the `sample-blog` project is created with the new shape (manual smoke if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)