### PR TITLE
Fix sorting by displayName #171

### DIFF
--- a/src/main/resources/import/superhero/_/node.xml
+++ b/src/main/resources/import/superhero/_/node.xml
@@ -564,6 +564,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/_templates/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/_/node.xml
@@ -136,6 +136,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig/>
     </indexConfigs>

--- a/src/main/resources/import/superhero/_templates/default/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/default/_/node.xml
@@ -256,6 +256,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/_templates/post-show-2-columns/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/post-show-2-columns/_/node.xml
@@ -522,6 +522,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/_templates/post-show-one-column/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/post-show-one-column/_/node.xml
@@ -311,6 +311,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/authors/_/node.xml
+++ b/src/main/resources/import/superhero/authors/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/authors/kari-nordmann/_/node.xml
+++ b/src/main/resources/import/superhero/authors/kari-nordmann/_/node.xml
@@ -141,6 +141,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/authors/ola-nordmann/_/node.xml
+++ b/src/main/resources/import/superhero/authors/ola-nordmann/_/node.xml
@@ -141,6 +141,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/categories/_/node.xml
+++ b/src/main/resources/import/superhero/categories/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/categories/parent/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/categories/parent/first-child-category/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/first-child-category/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/categories/parent/first-child-category/one-grandchild-category/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/first-child-category/one-grandchild-category/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/categories/parent/second-child-category/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/second-child-category/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/categories/uncategorized/_/node.xml
+++ b/src/main/resources/import/superhero/categories/uncategorized/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/_/node.xml
+++ b/src/main/resources/import/superhero/posts/_/node.xml
@@ -137,6 +137,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/category-hierarchy/_/node.xml
+++ b/src/main/resources/import/superhero/posts/category-hierarchy/_/node.xml
@@ -144,6 +144,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/elements/_/node.xml
+++ b/src/main/resources/import/superhero/posts/elements/_/node.xml
@@ -214,6 +214,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/featured-image/_/node.xml
+++ b/src/main/resources/import/superhero/posts/featured-image/_/node.xml
@@ -145,6 +145,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/featured-image/superhero_5.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/featured-image/superhero_5.jpg/_/node.xml
@@ -196,6 +196,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/_/node.xml
+++ b/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/_/node.xml
@@ -145,6 +145,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/superhero_featured_3.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/superhero_featured_3.jpg/_/node.xml
@@ -196,6 +196,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/hello-world/_/node.xml
+++ b/src/main/resources/import/superhero/posts/hello-world/_/node.xml
@@ -277,6 +277,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/html/_/node.xml
+++ b/src/main/resources/import/superhero/posts/html/_/node.xml
@@ -211,6 +211,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/links/_/node.xml
+++ b/src/main/resources/import/superhero/posts/links/_/node.xml
@@ -177,6 +177,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/march-madness/_/node.xml
+++ b/src/main/resources/import/superhero/posts/march-madness/_/node.xml
@@ -146,6 +146,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/more-tags/_/node.xml
+++ b/src/main/resources/import/superhero/posts/more-tags/_/node.xml
@@ -177,6 +177,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/_/node.xml
@@ -146,6 +146,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_4.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_4.jpg/_/node.xml
@@ -196,6 +196,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_featured_4.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_featured_4.jpg/_/node.xml
@@ -196,6 +196,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/posts/worth-a-thousand-words/_/node.xml
+++ b/src/main/resources/import/superhero/posts/worth-a-thousand-words/_/node.xml
@@ -143,6 +143,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>

--- a/src/main/resources/import/superhero/search/_/node.xml
+++ b/src/main/resources/import/superhero/search/_/node.xml
@@ -304,6 +304,19 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayName</path>
+            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
             <languages>


### PR DESCRIPTION
## Summary

The imported demo nodes (`src/main/resources/import/superhero/.../node.xml`) lacked a `displayName` `pathIndexConfig` with the project's language analyzer. As a result, the ES `_orderby_en` field was not populated for them, so child-order `displayName ASC/DESC` did not produce the same collation as freshly created content.

This PR adds a `displayName` `pathIndexConfig` to all 31 imported `node.xml` files, matching what XP's `LanguageConfigProcessor` adds for a content created under a `language=en` project:

```xml
<pathIndexConfig>
    <indexConfig>
        <decideByType>false</decideByType>
        <enabled>true</enabled>
        <nGram>true</nGram>
        <fulltext>true</fulltext>
        <includeInAllText>true</includeInAllText>
        <languages>
            <language>en</language>
        </languages>
    </indexConfig>
    <path>displayName</path>
</pathIndexConfig>
```

(Settings copied from `IndexConfig.FULLTEXT` plus `addLanguage(en)` — see `LanguageConfigProcessor.java` in `xp`.)

## Test plan

Verified locally against XP 8.0.0-SNAPSHOT:

- [x] Built `xp-distro`, dropped a built `superhero.jar` into a fresh install, booted it.
- [x] After import, inspected `_indexConfig` for `/content/superhero`, `/content/superhero/posts`, `/content/superhero/posts/hello-world`, `/content/superhero/_templates`, `/content/superhero/categories`. All show `displayname` config with `languages: ["en"]` and `fulltext/nGram/includeInAllText: true`.
- [x] `nodeLib.findChildren({parentKey:'/content/superhero/posts', childOrder:'displayName ASC'})` returns posts in English alphabetical order (`Category Hierarchy`, `Elements`, `Featured Image`, `Gotham Sure Is A Big Town`, `Hello world!`, `HTML`, `Links`, `March Madness`, `More Tags`, `Some Buildings to Leap`, `Worth A Thousand Words`); `DESC` reverses correctly.
- [x] Created a fresh folder via `contentLib.create({displayName:'AAA Fresh Test', parentPath:'/superhero/posts'})` — it interleaves at the correct sort position alongside the imported nodes, confirming the imported indexConfig is consistent with what `ContentService.create` produces.

Closes #171