### PR TITLE
Generic import rewrite + project roles #173

### DIFF
--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -3,10 +3,12 @@
   <xsl:output method="xml" indent="yes"/>
 
   <xsl:param name="applicationId"/>
-  <xsl:param name="applicationIdPlaceholder"/>
   <xsl:param name="projectName"/>
-  <xsl:param name="projectNamePlaceholder"/>
   <xsl:param name="keepPublishFirst" select="'true'"/>
+
+  <!-- Values the bundled /import data was exported with -->
+  <xsl:variable name="applicationIdPlaceholder" select="'com.enonic.app.superhero'"/>
+  <xsl:variable name="projectNamePlaceholder" select="'sample-blog'"/>
 
   <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
   <xsl:variable name="applicationIdPlaceholderDashed" select="translate($applicationIdPlaceholder, '.', '-')"/>

--- a/src/main/resources/import/replace_app.xsl
+++ b/src/main/resources/import/replace_app.xsl
@@ -1,19 +1,52 @@
 <?xml version="1.0"?>
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-    <xsl:output method="xml" indent="yes"/>
-    <xsl:param name="keepPublishFirst" select="'true'"/>
+  <xsl:output method="xml" indent="yes"/>
 
-    <xsl:template match="data/property-set[@name='publish']">
-        <xsl:if test="$keepPublishFirst != 'false'">
-            <xsl:copy>
-                <xsl:apply-templates select="@*|*[@name='first']"/>
-            </xsl:copy>
-        </xsl:if>
-    </xsl:template>
+  <xsl:param name="applicationId"/>
+  <xsl:param name="applicationIdPlaceholder"/>
+  <xsl:param name="projectName"/>
+  <xsl:param name="projectNamePlaceholder"/>
+  <xsl:param name="keepPublishFirst" select="'true'"/>
 
-    <xsl:template match="@*|node()">
-        <xsl:copy>
-            <xsl:apply-templates select="@*|node()"/>
-        </xsl:copy>
-    </xsl:template>
+  <xsl:variable name="applicationIdDashed" select="translate($applicationId, '.', '-')"/>
+  <xsl:variable name="applicationIdPlaceholderDashed" select="translate($applicationIdPlaceholder, '.', '-')"/>
+
+  <!-- app key inside descriptor-style string values: "<app>:descriptor" -->
+  <xsl:template match="string[starts-with(text(), concat($applicationIdPlaceholder, ':'))]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="concat($applicationId, substring-after(., $applicationIdPlaceholder))"/>
+    </string>
+  </xsl:template>
+
+  <!-- bare app key string value -->
+  <xsl:template match="string[text() = $applicationIdPlaceholder]">
+    <string>
+      <xsl:attribute name="name"><xsl:value-of select="@name"/></xsl:attribute>
+      <xsl:value-of select="$applicationId"/>
+    </string>
+  </xsl:template>
+
+  <!-- dashed app key in property-set names (x.<dashed-app>...) -->
+  <xsl:template match="property-set/@name[. = $applicationIdPlaceholderDashed]">
+    <xsl:attribute name="name"><xsl:value-of select="$applicationIdDashed"/></xsl:attribute>
+  </xsl:template>
+
+  <!-- project-role principals: role:cms.project.<placeholder>.<suffix> -->
+  <xsl:template match="principal/@key[starts-with(., concat('role:cms.project.', $projectNamePlaceholder, '.'))]">
+    <xsl:attribute name="key">
+      <xsl:value-of select="concat('role:cms.project.', $projectName, '.', substring-after(., concat('role:cms.project.', $projectNamePlaceholder, '.')))"/>
+    </xsl:attribute>
+  </xsl:template>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy><xsl:apply-templates select="@*|node()"/></xsl:copy>
+  </xsl:template>
+
+  <!-- Remove publishing metadata on import -->
+  <xsl:template match="data/property-set[@name='publish']">
+    <xsl:if test="$keepPublishFirst != 'false'">
+      <xsl:copy><xsl:apply-templates select="@*|*[@name='first']"/></xsl:copy>
+    </xsl:if>
+  </xsl:template>
 </xsl:stylesheet>

--- a/src/main/resources/import/superhero/_/node.xml
+++ b/src/main/resources/import/superhero/_/node.xml
@@ -2,8 +2,7 @@
     <id>251e6b26-5d9d-4337-981c-bc440e4076aa</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.021Z</timestamp>
-    <inheritPermissions>false</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.733Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -218,6 +262,11 @@
                 </property-set>
             </property-set>
         </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.377Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -266,16 +315,6 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>components.part.config.com-enonic-app-superhero.latest-comments.*</path>
-            </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>true</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>false</nGram>
-                    <fulltext>false</fulltext>
-                    <includeInAllText>false</includeInAllText>
-                </indexConfig>
                 <path>components.part.config.com-enonic-app-superhero.posts-list.*</path>
             </pathIndexConfig>
             <pathIndexConfig>
@@ -287,6 +326,16 @@
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
                 <path>components.part.config.com-enonic-app-superhero.meta.*</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>true</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.part.config.com-enonic-app-superhero.latest-comments.*</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -349,7 +398,7 @@
                         <indexValueProcessor>htmlStripper</indexValueProcessor>
                     </indexValueProcessors>
                 </indexConfig>
-                <path>data.siteConfig.config.footerText</path>
+                <path>data.siteconfig.config.footertext</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -359,7 +408,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>data.siteConfig.applicationkey</path>
+                <path>data.siteconfig.applicationkey</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -512,7 +561,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -542,7 +604,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -564,21 +626,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/_templates/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/_/node.xml
@@ -2,8 +2,7 @@
     <id>1d9e1197-e02b-4982-996b-b4638a760804</id>
     <childOrder>_manualordervalue DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.162Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.752Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -46,6 +90,11 @@
         <dateTime name="modifiedTime">2020-02-27T23:46:39.249Z</dateTime>
         <string name="owner">user:system:su</string>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.429Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -108,6 +157,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -136,20 +198,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
-        <allTextIndexConfig/>
+        <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
+        </allTextIndexConfig>
     </indexConfigs>
 </node>

--- a/src/main/resources/import/superhero/_templates/default/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/default/_/node.xml
@@ -2,8 +2,7 @@
     <id>52514ac0-29a3-4775-b62a-e43db6696343</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.208Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.786Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -62,6 +106,11 @@
                     </property-set>
                 </property-set>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.448Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -218,6 +267,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -256,21 +318,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/_templates/post-show-2-columns/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/post-show-2-columns/_/node.xml
@@ -2,8 +2,7 @@
     <id>87839c1e-aaeb-4f06-9d98-0df053361eac</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.178Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.794Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -206,6 +250,11 @@
                 </property-set>
             </property-set>
         </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.470Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -254,16 +303,6 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>components.part.config.com-enonic-app-superhero.latest-comments.*</path>
-            </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>true</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>false</nGram>
-                    <fulltext>false</fulltext>
-                    <includeInAllText>false</includeInAllText>
-                </indexConfig>
                 <path>components.part.config.com-enonic-app-superhero.post-single.*</path>
             </pathIndexConfig>
             <pathIndexConfig>
@@ -275,6 +314,16 @@
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
                 <path>components.part.config.com-enonic-app-superhero.meta.*</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>true</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>false</nGram>
+                    <fulltext>false</fulltext>
+                    <includeInAllText>false</includeInAllText>
+                </indexConfig>
+                <path>components.part.config.com-enonic-app-superhero.latest-comments.*</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -470,7 +519,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -500,7 +562,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -522,21 +584,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/_templates/post-show-one-column/_/node.xml
+++ b/src/main/resources/import/superhero/_templates/post-show-one-column/_/node.xml
@@ -2,8 +2,7 @@
     <id>f58b346b-774c-4383-83d3-c14f0474da60</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.200Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.808Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -97,6 +141,11 @@
                     </property-set>
                 </property-set>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.500Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -273,6 +322,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -311,21 +373,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/authors/_/node.xml
+++ b/src/main/resources/import/superhero/authors/_/node.xml
@@ -2,8 +2,7 @@
     <id>a9b46863-f9a1-4f5a-9875-f8b736215a55</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.133Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.757Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2020-02-27T23:48:49.691Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.520Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/authors/kari-nordmann/_/node.xml
+++ b/src/main/resources/import/superhero/authors/kari-nordmann/_/node.xml
@@ -2,8 +2,7 @@
     <id>22354f06-b64e-48d8-959d-da5f8c27a424</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.153Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.819Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -50,6 +94,11 @@
             <string name="email">kari@example.com</string>
             <string name="website">https://example.com</string>
             <string name="bio">&lt;p&gt;I'm the blog admin!&lt;/p&gt;</string>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.536Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -113,6 +162,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -141,21 +203,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/authors/ola-nordmann/_/node.xml
+++ b/src/main/resources/import/superhero/authors/ola-nordmann/_/node.xml
@@ -2,8 +2,7 @@
     <id>86cc1301-0639-41d1-84ed-70ba443f38ba</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.144Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.830Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -50,6 +94,11 @@
             <string name="email">ola@example.com</string>
             <string name="website">https://example.com</string>
             <string name="bio">This is my bio. There are many like it but this one is mine.</string>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.558Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -113,6 +162,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -141,21 +203,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/categories/_/node.xml
+++ b/src/main/resources/import/superhero/categories/_/node.xml
@@ -2,8 +2,7 @@
     <id>38d36fd3-be0c-48a4-afc8-2aa8c83c9f0c</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.066Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.763Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2020-02-27T23:49:04.378Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.583Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/categories/parent/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/_/node.xml
@@ -2,8 +2,7 @@
     <id>70ac4676-678d-408e-9561-fe98ddcc13be</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.096Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.835Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2020-02-27T23:50:55.706Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.605Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/categories/parent/first-child-category/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/first-child-category/_/node.xml
@@ -2,8 +2,7 @@
     <id>e656bc02-10dd-45b1-b30f-c9deef28aa6f</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.116Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.844Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2020-02-27T23:51:15.641Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.620Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/categories/parent/first-child-category/one-grandchild-category/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/first-child-category/one-grandchild-category/_/node.xml
@@ -2,8 +2,7 @@
     <id>db5af3a3-6f57-4c7f-b7fb-15794e25ddb3</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.126Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.854Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2020-02-27T23:51:44.387Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.637Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/categories/parent/second-child-category/_/node.xml
+++ b/src/main/resources/import/superhero/categories/parent/second-child-category/_/node.xml
@@ -2,8 +2,7 @@
     <id>11b7c8c5-5633-47d3-a488-9c4d5060b690</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.107Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.849Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2020-02-27T23:51:30.611Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.658Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/categories/uncategorized/_/node.xml
+++ b/src/main/resources/import/superhero/categories/uncategorized/_/node.xml
@@ -2,8 +2,7 @@
     <id>f4386113-1bee-41c3-9fd9-dd6c04e903bb</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.087Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.839Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <string name="creator">user:system:su</string>
         <dateTime name="createdTime">2020-02-27T23:51:58.526Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.689Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/_/node.xml
+++ b/src/main/resources/import/superhero/posts/_/node.xml
@@ -2,8 +2,7 @@
     <id>64f66a5c-b933-410c-a24c-a1192b4a0c49</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.217Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.775Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -47,6 +91,11 @@
         <dateTime name="createdTime">2020-02-27T23:49:33.535Z</dateTime>
         <dateTime name="modifiedTime">2020-02-27T23:49:33.535Z</dateTime>
         <property-set name="data"/>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.703Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -109,6 +158,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -137,21 +199,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/category-hierarchy/_/node.xml
+++ b/src/main/resources/import/superhero/posts/category-hierarchy/_/node.xml
@@ -2,8 +2,7 @@
     <id>5f579f93-c4d9-42f6-b225-ae13732d7489</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.235Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.860Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -53,6 +97,11 @@
             <reference name="category">db5af3a3-6f57-4c7f-b7fb-15794e25ddb3</reference>
             <reference name="category">11b7c8c5-5633-47d3-a488-9c4d5060b690</reference>
             <string name="post">&lt;p&gt;This post has 4 categories, part of a hierarchy that is 3 deep.&lt;br /&gt;Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Fusce euismod commodo ante. Suspendisse potenti. Nunc pellentesque quam vel pede. Ut a lorem non urna molestie euismod. Fusce consequat tortor eu urna. Pellentesque aliquam, pede eget tincidunt feugiat, nunc massa hendrerit magna, non ultricies neque lectus nec dui. In hac habitasse platea dictumst.Sed feugiat quam eget lectus. Fusce at pede. Morbi sagittis tristique tortor. Sed erat justo, blandit ac, dignissim in, pretium ut, urna.&lt;/p&gt;</string>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.718Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -116,6 +165,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -144,21 +206,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/elements/_/node.xml
+++ b/src/main/resources/import/superhero/posts/elements/_/node.xml
@@ -2,8 +2,7 @@
     <id>f1bf2f22-08dc-4e28-afa8-253e523b06a2</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.244Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.866Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -124,6 +168,11 @@
             <boolean name="stickyPost">false</boolean>
             <boolean name="slideshow">false</boolean>
         </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.737Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
+        </property-set>
     </data>
     <indexConfigs>
         <defaultConfig>
@@ -186,6 +235,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -214,21 +276,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/featured-image/_/node.xml
+++ b/src/main/resources/import/superhero/posts/featured-image/_/node.xml
@@ -2,8 +2,7 @@
     <id>086d5877-6f0f-4514-ab16-fcfe43f28bdf</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.259Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.875Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -54,6 +98,11 @@
             <boolean name="stickyPost">false</boolean>
             <reference name="featuredImage">be1ca151-cf61-4a54-9ea4-c8d01ce83e0e</reference>
             <boolean name="slideshow">false</boolean>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.764Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -117,6 +166,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -145,21 +207,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/featured-image/superhero_5.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/featured-image/superhero_5.jpg/_/node.xml
@@ -116,6 +116,8 @@
             <binaryReference name="binary">superhero_5.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">196646</long>
+            <string name="sha512">8e01a30813fd7e098094e8d5f11ec268c0e3d0ed3d1b46de572cae1fa3f6d237669b883bd4d9514bc4cad059db8d01821de86ce011c86d850bb064d7ad14933a</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="time">2026-05-29T07:29:14.788Z</dateTime>

--- a/src/main/resources/import/superhero/posts/featured-image/superhero_5.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/featured-image/superhero_5.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>be1ca151-cf61-4a54-9ea4-c8d01ce83e0e</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.268Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.928Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -72,6 +116,11 @@
             <binaryReference name="binary">superhero_5.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">196646</long>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.788Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -154,7 +203,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -184,7 +246,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -196,21 +258,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/_/node.xml
+++ b/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/_/node.xml
@@ -2,8 +2,7 @@
     <id>5e7ccee7-6d82-4729-8628-4f7933657803</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.276Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.880Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -54,6 +98,11 @@
             <boolean name="stickyPost">false</boolean>
             <reference name="featuredImage">43d54e23-d8ce-4058-befb-777abe1a0d9f</reference>
             <boolean name="slideshow">true</boolean>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.806Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -117,6 +166,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -145,21 +207,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/superhero_featured_3.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/superhero_featured_3.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>43d54e23-d8ce-4058-befb-777abe1a0d9f</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.286Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.936Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -72,6 +116,11 @@
             <binaryReference name="binary">superhero_featured_3.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">362035</long>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.823Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -154,7 +203,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -184,7 +246,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -196,21 +258,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/superhero_featured_3.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/gotham-sure-is-a-big-town/superhero_featured_3.jpg/_/node.xml
@@ -116,6 +116,8 @@
             <binaryReference name="binary">superhero_featured_3.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">362035</long>
+            <string name="sha512">fc799fb95d66c92c834f1331d4877faaa3925821287140d42742648d67176211e81e04963a31c152b0c2c2fb4d919f1f3da925c2cf7bf93c790a4244fd9410da</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="time">2026-05-29T07:29:14.823Z</dateTime>

--- a/src/main/resources/import/superhero/posts/hello-world/_/node.xml
+++ b/src/main/resources/import/superhero/posts/hello-world/_/node.xml
@@ -2,8 +2,7 @@
     <id>186721fd-1866-46c7-a673-a6ffbcbcaadb</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.300Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.886Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -60,6 +104,11 @@
                 <reference name="template">87839c1e-aaeb-4f06-9d98-0df053361eac</reference>
                 <boolean name="customized">false</boolean>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.847Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -225,7 +274,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -255,7 +317,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -277,21 +339,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/html/_/node.xml
+++ b/src/main/resources/import/superhero/posts/html/_/node.xml
@@ -2,8 +2,7 @@
     <id>566e3f36-ff84-476c-b36a-34d97a9862c5</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.310Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.892Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -87,6 +131,11 @@
             <string name="tags">html</string>
             <boolean name="stickyPost">false</boolean>
             <boolean name="slideshow">false</boolean>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.863Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -169,7 +218,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -199,7 +261,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -211,21 +273,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/links/_/node.xml
+++ b/src/main/resources/import/superhero/posts/links/_/node.xml
@@ -2,8 +2,7 @@
     <id>886dfc12-70ed-44a1-92b0-7bebffe65ab6</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.322Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.900Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -53,6 +97,11 @@
             <boolean name="stickyPost">false</boolean>
             <boolean name="slideshow">false</boolean>
             <string name="tags">Enonic XP</string>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.885Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -135,7 +184,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -165,7 +227,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -177,21 +239,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/march-madness/_/node.xml
+++ b/src/main/resources/import/superhero/posts/march-madness/_/node.xml
@@ -2,8 +2,7 @@
     <id>8f6fed07-6d7c-4f31-b7ee-5fe9e9b7a3bf</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.332Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.905Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -55,6 +99,11 @@
             <string name="tags">sticky</string>
             <boolean name="stickyPost">true</boolean>
             <boolean name="slideshow">false</boolean>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.901Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -118,6 +167,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -146,21 +208,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/more-tags/_/node.xml
+++ b/src/main/resources/import/superhero/posts/more-tags/_/node.xml
@@ -2,8 +2,7 @@
     <id>df6e7c83-946f-4b57-b1ce-20c965adaaee</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.399Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.911Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -53,6 +97,11 @@
             <string name="tags">Enonic XP</string>
             <boolean name="stickyPost">false</boolean>
             <boolean name="slideshow">false</boolean>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.918Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -135,7 +184,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -165,7 +227,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -177,21 +239,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/_/node.xml
@@ -2,8 +2,7 @@
     <id>03ff15b2-954c-4131-b58f-7bcd84698dd0</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.406Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.916Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -55,6 +99,11 @@
             <boolean name="stickyPost">false</boolean>
             <reference name="featuredImage">81b1e3cd-575f-4565-a618-3c85d56224f6</reference>
             <boolean name="slideshow">true</boolean>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.939Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -118,6 +167,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -146,21 +208,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_4.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_4.jpg/_/node.xml
@@ -116,6 +116,8 @@
             <binaryReference name="binary">superhero_4.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">146481</long>
+            <string name="sha512">bae45197c45375f517696b925635945814968b231e6e4a62ff79e83a06cbd87879e866f0c7a9911a4281f4fb69c745f3baaa72c0c4fd9c3bbef28a95dd2a6d92</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="time">2026-05-29T07:29:14.961Z</dateTime>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_4.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_4.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>32169e70-49e1-444c-a6ac-d38f22438134</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.415Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.942Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -72,6 +116,11 @@
             <binaryReference name="binary">superhero_4.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">146481</long>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.961Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -154,7 +203,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -184,7 +246,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -196,21 +258,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_featured_4.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_featured_4.jpg/_/node.xml
@@ -116,6 +116,8 @@
             <binaryReference name="binary">superhero_featured_4.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">548842</long>
+            <string name="sha512">3ea3f5388f8f3f5e6b6f8161e4120cb7a77cd403b142798168dfe5e947dcf178bfc82f241ce4bd82eb1da0e17fb0c3c5a29d1939b1f184a1bde6fff001bab74d</string>
+            <string name="text"/>
         </property-set>
         <property-set name="publish">
             <dateTime name="time">2026-05-29T07:29:14.978Z</dateTime>

--- a/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_featured_4.jpg/_/node.xml
+++ b/src/main/resources/import/superhero/posts/some-buildings-to-leap/superhero_featured_4.jpg/_/node.xml
@@ -2,8 +2,7 @@
     <id>81b1e3cd-575f-4565-a618-3c85d56224f6</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.422Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.948Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -30,6 +29,51 @@
             <deny type="array"/>
         </principal>
         <principal key="role:system.everyone">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
             <allow type="array">
                 <value>READ</value>
             </allow>
@@ -72,6 +116,11 @@
             <binaryReference name="binary">superhero_featured_4.jpg</binaryReference>
             <string name="mimeType">image/jpeg</string>
             <long name="size">548842</long>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.978Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -154,7 +203,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -184,7 +246,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -196,21 +258,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/posts/worth-a-thousand-words/_/node.xml
+++ b/src/main/resources/import/superhero/posts/worth-a-thousand-words/_/node.xml
@@ -2,8 +2,7 @@
     <id>bdc9b662-578f-406a-8577-bea4555772db</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.430Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.921Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -52,6 +96,11 @@
             <string name="post">&lt;div style="width: 445px;" class="wp-caption alignnone"&gt;&lt;img class="wp-image-59" alt="Boat" src="https://wpdotorg.files.wordpress.com/2008/11/boat.jpg" width="435" height="288" /&gt;&lt;/div&gt;</string>
             <string name="tags">boat</string>
             <string name="tags">lake</string>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:14.995Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -115,6 +164,19 @@
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
                     <decideByType>true</decideByType>
                     <enabled>true</enabled>
                     <nGram>false</nGram>
@@ -143,21 +205,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/import/superhero/search/_/node.xml
+++ b/src/main/resources/import/superhero/search/_/node.xml
@@ -2,8 +2,7 @@
     <id>45939e50-afb5-4f02-9fee-66489c74475e</id>
     <childOrder>modifiedtime DESC</childOrder>
     <nodeType>content</nodeType>
-    <timestamp>2019-03-13T08:48:27.437Z</timestamp>
-    <inheritPermissions>true</inheritPermissions>
+    <timestamp>2026-05-29T07:29:15.780Z</timestamp>
     <permissions>
         <principal key="role:system.admin">
             <allow type="array">
@@ -35,6 +34,51 @@
             </allow>
             <deny type="array"/>
         </principal>
+        <principal key="role:cms.project.sample-blog.owner">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.editor">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+                <value>PUBLISH</value>
+                <value>READ_PERMISSIONS</value>
+                <value>WRITE_PERMISSIONS</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.author">
+            <allow type="array">
+                <value>READ</value>
+                <value>CREATE</value>
+                <value>MODIFY</value>
+                <value>DELETE</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.contributor">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
+        <principal key="role:cms.project.sample-blog.viewer">
+            <allow type="array">
+                <value>READ</value>
+            </allow>
+            <deny type="array"/>
+        </principal>
     </permissions>
     <data>
         <boolean name="valid">true</boolean>
@@ -48,8 +92,7 @@
         <dateTime name="modifiedTime">2020-04-08T08:44:20.878Z</dateTime>
         <property-set name="data"/>
         <property-set name="x">
-            <property-set name="com-enonic-app-superhero">
-            </property-set>
+            <property-set name="com-enonic-app-superhero"/>
         </property-set>
         <property-set name="components">
             <string name="type">page</string>
@@ -70,6 +113,11 @@
                     </property-set>
                 </property-set>
             </property-set>
+        </property-set>
+        <property-set name="publish">
+            <dateTime name="time">2026-05-29T07:29:15.012Z</dateTime>
+            <dateTime name="from">2026-05-29T07:29:14.231Z</dateTime>
+            <dateTime name="first">2026-05-29T07:29:14.231Z</dateTime>
         </property-set>
     </data>
     <indexConfigs>
@@ -252,7 +300,20 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>modifiedTime</path>
+                <path>modifiedtime</path>
+            </pathIndexConfig>
+            <pathIndexConfig>
+                <indexConfig>
+                    <decideByType>false</decideByType>
+                    <enabled>true</enabled>
+                    <nGram>true</nGram>
+                    <fulltext>true</fulltext>
+                    <includeInAllText>true</includeInAllText>
+                    <languages>
+                        <language>en</language>
+                    </languages>
+                </indexConfig>
+                <path>displayname</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -282,7 +343,7 @@
                     <fulltext>false</fulltext>
                     <includeInAllText>false</includeInAllText>
                 </indexConfig>
-                <path>createdTime</path>
+                <path>createdtime</path>
             </pathIndexConfig>
             <pathIndexConfig>
                 <indexConfig>
@@ -304,21 +365,11 @@
                 </indexConfig>
                 <path>attachment</path>
             </pathIndexConfig>
-            <pathIndexConfig>
-                <indexConfig>
-                    <decideByType>false</decideByType>
-                    <enabled>true</enabled>
-                    <nGram>true</nGram>
-                    <fulltext>true</fulltext>
-                    <includeInAllText>true</includeInAllText>
-                    <languages>
-                        <language>en</language>
-                    </languages>
-                </indexConfig>
-                <path>displayName</path>
-            </pathIndexConfig>
         </pathIndexConfigs>
         <allTextIndexConfig>
+            <enabled>true</enabled>
+            <nGram>true</nGram>
+            <fulltext>true</fulltext>
             <languages>
                 <language>en</language>
             </languages>

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -11,7 +11,9 @@ const projectData = {
     displayName: 'Superhero Blog',
     description: 'Sample blog site on Enonic XP',
     language: 'en',
-    publicRead: true
+    readAccess: {
+        public: true
+    }
 }
 
 
@@ -19,9 +21,12 @@ const runInContext = function (callback) {
     let result;
     try {
         result = contextLib.run({
-            branch: 'draft',
-            principals: ["role:system.admin"],
-            repository: 'com.enonic.cms.' + projectData.id
+            user: {
+                login: "su",
+                idProvider: "system"
+            },
+            repository: 'com.enonic.cms.' + projectData.id,
+            branch: 'draft'
         }, callback);
     } catch (e) {
         log.info('Error: ' + e.message);
@@ -85,11 +90,14 @@ function createContent() {
         targetNodePath: '/content',
         xslt: resolve('/import/replace_app.xsl'),
         xsltParams: {
-            applicationId: app.name
+            applicationId: app.name,
+            applicationIdPlaceholder: 'com.enonic.app.superhero',
+            projectName: projectData.id,
+            projectNamePlaceholder: 'sample-blog'
         },
         versionAttributes: {
             'content.import': {
-                user: "role:system.admin",
+                user: contextLib.get().authInfo.user.key,
                 optime: new Date().toISOString()
             },
             'vacuum.skip': {}
@@ -108,12 +116,16 @@ function publishRoot() {
         keys: ['/superhero'],
         sourceBranch: 'draft',
         targetBranch: 'master',
+        includeChildren: true,
+        includeDependencies: true,
     });
-    if (!result) {
-       log.warning('Could not publish imported content.');
+    if (!result || (result.failedContents && result.failedContents.length > 0)) {
+        log.warning('Could not publish imported content. failed=' + JSON.stringify(result && result.failedContents));
+    } else {
+        log.info('Published ' + (result.pushedContents ? result.pushedContents.length : 0) + ' content items.');
     }
 }
 
-if (clusterLib.isMaster()) {
+if (clusterLib.isLeader()) {
     initialize();
 }

--- a/src/main/resources/main.js
+++ b/src/main/resources/main.js
@@ -91,9 +91,7 @@ function createContent() {
         xslt: resolve('/import/replace_app.xsl'),
         xsltParams: {
             applicationId: app.name,
-            applicationIdPlaceholder: 'com.enonic.app.superhero',
-            projectName: projectData.id,
-            projectNamePlaceholder: 'sample-blog'
+            projectName: projectData.id
         },
         versionAttributes: {
             'content.import': {


### PR DESCRIPTION
Fixes #173

## Summary

The superhero demo importer is now generic and fork-safe. Two pieces:

### `src/main/resources/import/replace_app.xsl`
Fully parameter-driven — no concrete app key or project name appears in the stylesheet anymore. It takes:
- `applicationId` + `applicationIdPlaceholder` (dotted; dashed variant derived via `translate(., '.', '-')`)
- `projectName` + `projectNamePlaceholder`
- `keepPublishFirst` (default `'true'`)

Templates rewrite dotted descriptor-style strings (`<app>:descriptor`), bare app-key strings, dashed property-set names (`x.<dashed-app>...`), and `role:cms.project.<placeholder>.*` principal keys. The `principal/@key` template is **scoped to** `role:cms.project.<placeholder>.` so `role:system.admin` / `role:cms.admin` / `role:system.everyone` are left untouched.

The same stylesheet is being applied to `enonic/app-hmdb` (companion task) — the two files are byte-for-byte identical.

### `src/main/resources/main.js`
Passes the concrete superhero values as `xsltParams`:

```js
xsltParams: {
    applicationId: app.name,
    applicationIdPlaceholder: 'com.enonic.app.superhero',
    projectName: projectData.id,
    projectNamePlaceholder: 'sample-blog'
}
```

A fork that renames the project / app key now gets correct `role:cms.project.<new-id>.*` bindings on imported content. The XSLT itself stays repo-agnostic.

### Re-exported `/superhero` data
The 31 bundled `node.xml` files now carry the five project-role principals (`owner`, `editor`, `author`, `contributor`, `viewer`) alongside the legacy `role:system.admin` / `role:cms.admin` / `role:system.everyone`. Generated by re-exporting from a fresh XP 8 install after applying the canonical permission matrix via `lib/xp/node.applyPermissions` recursively.

## Test plan

- [x] `./gradlew build --refresh-dependencies` — green
- [x] Deployed jar to a fresh xp-distro 8.0.0-SNAPSHOT install; server.log shows:
  - `Started application com.enonic.app.superhero`
  - `Project "sample-blog" successfully created`
  - `Published 31 content items.`
  - no import errors
- [x] Server-side `lib/xp/node.get` on `/superhero` and descendants (`/superhero/posts`, `/superhero/categories/parent`) confirms all five `role:cms.project.sample-blog.*` principals present with correct allow matrices (owner/editor: full incl. PUBLISH/READ_PERMISSIONS/WRITE_PERMISSIONS; author: R/C/M/D; contributor + viewer: READ only).